### PR TITLE
:construction_worker: Add "releases" field to Component Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-component-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-component-request.yml
@@ -38,10 +38,8 @@ body:
   - type: input
     id: releases
     attributes:
-      label: "Release / Download URL"
-      description:
-        "A link to releases, downloads, or package artifact for the component, such as via PyPI. Can
-        be left blank if not available."
+      label: "PyPI Release URL"
+      description: "A link to the PyPI release of this project. Can be left blank if not available."
       placeholder: "https://..."
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/new-component-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-component-request.yml
@@ -36,6 +36,17 @@ body:
       required: false
 
   - type: input
+    id: releases
+    attributes:
+      label: "Release / Download URL"
+      description:
+        "A link to releases, downloads, or package artifact for the component, such as via PyPI. Can
+        be left blank if not available."
+      placeholder: "https://..."
+    validations:
+      required: false
+
+  - type: input
     id: github
     attributes:
       label: "GitHub Repository URL"

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -30,6 +30,7 @@ jobs:
           NAME="${{ steps.issue-parser.outputs.issueparser_name }}"
           MAINTAINERS="${{ steps.issue-parser.outputs.issueparser_maintainers }}"
           DOCS="${{ steps.issue-parser.outputs.issueparser_docs }}"
+          RELEASES="${{ steps.issue-parser.outputs.issueparser_releases }}"
           GITHUB_REPO="${{ steps.issue-parser.outputs.issueparser_github }}"
           DESCRIPTION="${{ steps.issue-parser.outputs.issueparser_description }}"
           LANGUAGES="${{ steps.issue-parser.outputs.issueparser_languages }}"
@@ -57,13 +58,16 @@ jobs:
           echo -e "languages: $LANG_ARRAY" >> "_components/${SANITIZED_NAME}.md"
           echo -e "frameworks: $FW_ARRAY" >> "_components/${SANITIZED_NAME}.md"
 
-          if [ -n "$DOCS" ] || [ -n "$GITHUB_REPO" ]; then
+          if [ -n "$DOCS" ] || [ -n "$GITHUB_REPO" ] || [ -n "$RELEASES" ]; then
             echo -e "links:" >> "_components/${SANITIZED_NAME}.md"
             if [ -n "$DOCS" ]; then
               echo -e "  docs: \"${DOCS}\"" >> "_components/${SANITIZED_NAME}.md"
             fi
             if [ -n "$GITHUB_REPO" ]; then
               echo -e "  github: \"${GITHUB_REPO}\"" >> "_components/${SANITIZED_NAME}.md"
+            fi
+            if [ -n "$RELEASES" ]; then
+              echo -e "  releases: \"${RELEASES}\"" >> "_components/${SANITIZED_NAME}.md"
             fi
           fi
 

--- a/_components/mqt-core.md
+++ b/_components/mqt-core.md
@@ -5,6 +5,7 @@ frameworks: ["Qiskit", "MQT"]
 links:
   docs: "https://mqt.readthedocs.io/projects/core"
   github: "https://github.com/munich-quantum-toolkit/core"
+  releases: "https://pypi.org/project/mqt-core"
 maintainers: ["TUM (CDA) / MQSC"]
 ---
 

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ title: Component Overview
           {% endif %} {% if component.links.github %}
           <a href="{{ component.links.github }}" title="GitHub">GitHub</a>
           {% endif %} {% if component.links.releases %}
-          <a href="{{ component.links.releases }}" title="Releases">📦</a>
+          <a href="{{ component.links.releases }}" title="Releases">PyPI</a>
           {% endif %} {% if component.links.github %}
           <div class="github-stars" data-repo="{{ component.links.github }}">
             <span class="stars-icon">⭐</span>


### PR DESCRIPTION
This PR adds a "releases" field to add PyPI releases to the component form.
The feature was already implemented in the webpage itself, it just needed to be added to the form.

For testing purposes, this PR also adds the PyPI release link for MQT Core.