### PR TITLE
:sparkles: Update github stars fetching mechanism so that entries can be sorted by stars

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,21 @@ If the project uses Bundler, prefix with `bundle exec` (e.g. `bundle exec jekyll
 unsure, try `jekyll --version` and fall back to `bundle exec jekyll` when Gemfile/Bundler is
 present.
 
+Pre-commit hook (recommended):
+
+- This repo includes a `pre-commit` configuration and a small local hook that removes the transient
+  `stars` frontmatter from `_components/*.md` before a commit. That prevents accidentally committing
+  CI-injected `stars` values.
+- To enable locally:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The hook runs `python3 scripts/clean_frontmatter_stars.py` and will exit non-zero if it removed any
+`stars` entries so you can inspect changes before committing. This is optional but recommended.
+
 ## Integration points & gotchas
 
 - GitHub stars are fetched client-side from the public GitHub API. This works without auth but is

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -39,9 +39,12 @@ jobs:
           SANITIZED_NAME=$(echo "$NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[ \/]\+/-/g' -e 's/[^a-z0-9-]\+//g')
           BRANCH_NAME="new/component-${ISSUE_NUMBER}-${SANITIZED_NAME}"
 
-          LANG_ARRAY=$(echo "$LANGUAGES" | sed 's/[^,]\+/\"&\"/g' | sed 's/, /", "/g' | sed 's/.*/[&]/')
-          FW_ARRAY=$(echo "$FRAMEWORKS" | sed 's/[^,]\+/\"&\"/g' | sed 's/, /", "/g' | sed 's/.*/[&]/')
-          MAINT_ARRAY=$(echo "$MAINTAINERS" | sed 's/[^,]\+/\"&\"/g' | sed 's/, /", "/g' | sed 's/.*/[&]/')
+          # Build lists for languages/frameworks/maintainers as YAML block lists
+          # We'll emit these into the component file below (as:
+          # languages:
+          #   - "python"
+          #   - "c++"
+          # ) to prefer enumeration syntax over inline arrays.
 
           AUTHOR_NAME="${{ github.event.issue.user.login }}"
           AUTHOR_EMAIL="${{ github.event.issue.user.id }}+${{ github.event.issue.user.login }}@users.noreply.github.com"
@@ -53,25 +56,56 @@ jobs:
           # Create branch, add file, commit, and push
           git checkout -b $BRANCH_NAME
           echo -e "---" > "_components/${SANITIZED_NAME}.md"
-          echo -e "title: \"${NAME}\"" >> "_components/${SANITIZED_NAME}.md"
+          echo -e "title: ${NAME}" >> "_components/${SANITIZED_NAME}.md"
 
-          echo -e "languages: $LANG_ARRAY" >> "_components/${SANITIZED_NAME}.md"
-          echo -e "frameworks: $FW_ARRAY" >> "_components/${SANITIZED_NAME}.md"
+          # Write languages as a YAML block list if provided
+          if [ -n "$LANGUAGES" ]; then
+            echo "languages:" >> "_components/${SANITIZED_NAME}.md"
+            OLDIFS="$IFS"
+            IFS=','
+            for lang in $LANGUAGES; do
+              lang_trim=$(echo "$lang" | sed 's/^ *//; s/ *$//')
+              echo "  - \"${lang_trim}\"" >> "_components/${SANITIZED_NAME}.md"
+            done
+            IFS="$OLDIFS"
+          fi
+
+          # Write frameworks as a YAML block list if provided
+          if [ -n "$FRAMEWORKS" ]; then
+            echo "frameworks:" >> "_components/${SANITIZED_NAME}.md"
+            OLDIFS="$IFS"
+            IFS=','
+            for fw in $FRAMEWORKS; do
+              fw_trim=$(echo "$fw" | sed 's/^ *//; s/ *$//')
+              echo "  - \"${fw_trim}\"" >> "_components/${SANITIZED_NAME}.md"
+            done
+            IFS="$OLDIFS"
+          fi
 
           if [ -n "$DOCS" ] || [ -n "$GITHUB_REPO" ] || [ -n "$RELEASES" ]; then
             echo -e "links:" >> "_components/${SANITIZED_NAME}.md"
             if [ -n "$DOCS" ]; then
-              echo -e "  docs: \"${DOCS}\"" >> "_components/${SANITIZED_NAME}.md"
+              echo -e "  docs: ${DOCS}" >> "_components/${SANITIZED_NAME}.md"
             fi
             if [ -n "$GITHUB_REPO" ]; then
-              echo -e "  github: \"${GITHUB_REPO}\"" >> "_components/${SANITIZED_NAME}.md"
+              echo -e "  github: ${GITHUB_REPO}" >> "_components/${SANITIZED_NAME}.md"
             fi
             if [ -n "$RELEASES" ]; then
-              echo -e "  releases: \"${RELEASES}\"" >> "_components/${SANITIZED_NAME}.md"
+              echo -e "  releases: ${RELEASES}" >> "_components/${SANITIZED_NAME}.md"
             fi
           fi
 
-          echo -e "maintainers: $MAINT_ARRAY" >> "_components/${SANITIZED_NAME}.md"
+          # Write maintainers as a YAML block list
+          if [ -n "$MAINTAINERS" ]; then
+            echo "maintainers:" >> "_components/${SANITIZED_NAME}.md"
+            OLDIFS="$IFS"
+            IFS=','
+            for m in $MAINTAINERS; do
+              m_trim=$(echo "$m" | sed 's/^ *//; s/ *$//')
+              echo "  - \"${m_trim}\"" >> "_components/${SANITIZED_NAME}.md"
+            done
+            IFS="$OLDIFS"
+          fi
 
           echo -e "---" >> "_components/${SANITIZED_NAME}.md"
           echo -e "" >> "_components/${SANITIZED_NAME}.md"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site
+assets/js/github-stars.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,17 @@ ci:
   autofix_commit_msg: "🎨 pre-commit fixes"
 
 repos:
+  # Local hook: remove transient `stars` frontmatter from component files
+  - repo: local
+    hooks:
+      - id: remove-component-stars
+        name: Remove `stars` from component frontmatter
+        entry: python3 scripts/clean_frontmatter_stars.py
+        language: system
+        files: ^_components/.*\.md$
+        stages: [pre-commit]
+        pass_filenames: false
+
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -69,7 +80,7 @@ repos:
           - --tab-width=2
         exclude: ^docs/header\.html$
 
-  # Catch common capitalization mistakes
+  # Catch common capitalization mistakes (local)
   - repo: local
     hooks:
       - id: disallow-caps

--- a/_components/mqss-cudaq-adapter.md
+++ b/_components/mqss-cudaq-adapter.md
@@ -1,11 +1,15 @@
 ---
-title: "MQSS CUDAQ Adapter"
-languages: ["C++"]
-frameworks: ["LLVM", "MLIR"]
+title: MQSS CUDAQ Adapter
+languages:
+  - C++
+frameworks:
+  - LLVM
+  - MLIR
 links:
-  docs: "https://munich-quantum-software-stack.github.io/MQSS-Interfaces/cudaq/"
-  github: "https://github.com/Munich-Quantum-Software-Stack/MQSS-CUDAQ-Adapter"
-maintainers: ["LRZ (QCT)"]
+  docs: https://munich-quantum-software-stack.github.io/MQSS-Interfaces/cudaq/
+  github: https://github.com/Munich-Quantum-Software-Stack/MQSS-CUDAQ-Adapter
+maintainers:
+  - LRZ (QCT)
 ---
 
 Implementation of an adapter for the CUDA-Q programming interface to the MQSS.

--- a/_components/mqss-passes-suite.md
+++ b/_components/mqss-passes-suite.md
@@ -1,11 +1,14 @@
 ---
-title: "MQSS Passes Suite"
-languages: ["C++"]
-frameworks: ["LLVM"]
+title: MQSS Passes Suite
+languages:
+  - C++
+frameworks:
+  - LLVM
 links:
-  docs: "https://munich-quantum-software-stack.github.io/MQSS-Passes-Documentation/mlir/"
-  github: "https://github.com/Munich-Quantum-Software-Stack/MQSS-Passes-Suite"
-maintainers: ["LRZ (QCT)"]
+  docs: https://munich-quantum-software-stack.github.io/MQSS-Passes-Documentation/mlir/
+  github: https://github.com/Munich-Quantum-Software-Stack/MQSS-Passes-Suite
+maintainers:
+  - LRZ (QCT)
 ---
 
 A collection of compiler passes that target QIR and Quake.

--- a/_components/mqss-pennylane-adapter.md
+++ b/_components/mqss-pennylane-adapter.md
@@ -1,11 +1,14 @@
 ---
-title: "MQSS Pennylane Adapter"
-languages: ["Python"]
-frameworks: ["PennyLane"]
+title: MQSS Pennylane Adapter
+languages:
+  - Python
+frameworks:
+  - PennyLane
 links:
-  docs: "https://munich-quantum-software-stack.github.io/MQSS-Interfaces/pennylane/"
-  github: "https://github.com/Munich-Quantum-Software-Stack/MQSS-Pennylane-Adapter"
-maintainers: ["LRZ (QCT)"]
+  docs: https://munich-quantum-software-stack.github.io/MQSS-Interfaces/pennylane/
+  github: https://github.com/Munich-Quantum-Software-Stack/MQSS-Pennylane-Adapter
+maintainers:
+  - LRZ (QCT)
 ---
 
 Implementation of a custom PennyLane backend which enables users to send quantum jobs to LRZ's

--- a/_components/mqss-qdmi-devices-suite.md
+++ b/_components/mqss-qdmi-devices-suite.md
@@ -1,11 +1,15 @@
 ---
-title: "MQSS QDMI Devices Suite"
-languages: ["C", " C++"]
-frameworks: ["DCDB"]
+title: MQSS QDMI Devices Suite
+languages:
+  - C
+  - " C++"
+frameworks:
+  - DCDB
 links:
-  docs: "https://munich-quantum-software-stack.github.io/MQSS-QDMI-Devices-Suite/"
-  github: "https://github.com/Munich-Quantum-Software-Stack/MQSS-QDMI-Devices-Suite"
-maintainers: ["LRZ (QCT)"]
+  docs: https://munich-quantum-software-stack.github.io/MQSS-QDMI-Devices-Suite/
+  github: https://github.com/Munich-Quantum-Software-Stack/MQSS-QDMI-Devices-Suite
+maintainers:
+  - LRZ (QCT)
 ---
 
 A collection of QDMI device implementations for various quantum devices or emulators.

--- a/_components/mqss-qiskit-adapter.md
+++ b/_components/mqss-qiskit-adapter.md
@@ -1,11 +1,14 @@
 ---
-title: "MQSS Qiskit Adapter"
-languages: ["Python"]
-frameworks: ["Qiskit"]
+title: MQSS Qiskit Adapter
+languages:
+  - Python
+frameworks:
+  - Qiskit
 links:
-  docs: "https://munich-quantum-software-stack.github.io/MQSS-Interfaces/qiskit/"
-  github: "https://github.com/Munich-Quantum-Software-Stack/MQSS-Qiskit-Adapter"
-maintainers: ["LRZ (QCT)"]
+  docs: https://munich-quantum-software-stack.github.io/MQSS-Interfaces/qiskit/
+  github: https://github.com/Munich-Quantum-Software-Stack/MQSS-Qiskit-Adapter
+maintainers:
+  - LRZ (QCT)
 ---
 
 A Qiskit provider that allows submitting quantum jobs to LRZ's infrastructure.

--- a/_components/mqt-bench.md
+++ b/_components/mqt-bench.md
@@ -1,11 +1,15 @@
 ---
-title: "MQT Bench"
-languages: ["Python"]
-frameworks: ["Qiskit", "MQT"]
+title: MQT Bench
+languages:
+  - Python
+frameworks:
+  - Qiskit
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/bench"
-  github: "https://github.com/munich-quantum-toolkit/bench"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/bench
+  github: https://github.com/munich-quantum-toolkit/bench
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 A circuit benchmark suite offering the same algorithms across abstraction levels to evaluate quantum

--- a/_components/mqt-core.md
+++ b/_components/mqt-core.md
@@ -1,12 +1,17 @@
 ---
-title: "MQT Core"
-languages: ["C++", "Python"]
-frameworks: ["Qiskit", "MQT"]
+title: MQT Core
+languages:
+  - C++
+  - Python
+frameworks:
+  - Qiskit
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/core"
-  github: "https://github.com/munich-quantum-toolkit/core"
-  releases: "https://pypi.org/project/mqt-core"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/core
+  github: https://github.com/munich-quantum-toolkit/core
+  releases: https://pypi.org/project/mqt-core
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 MQT Core forms the backbone of the software tools developed as part of the Munich Quantum Toolkit

--- a/_components/mqt-ddsim.md
+++ b/_components/mqt-ddsim.md
@@ -1,11 +1,16 @@
 ---
-title: "MQT DDSIM"
-languages: ["Python", "C++"]
-frameworks: ["Qiskit", "MQT"]
+title: MQT DDSIM
+languages:
+  - Python
+  - C++
+frameworks:
+  - Qiskit
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/ddsim"
-  github: "https://github.com/munich-quantum-toolkit/ddsim"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/ddsim
+  github: https://github.com/munich-quantum-toolkit/ddsim
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 A classical quantum circuit simulator based on decision diagrams.

--- a/_components/mqt-debugger.md
+++ b/_components/mqt-debugger.md
@@ -1,11 +1,16 @@
 ---
-title: "MQT Debugger"
-languages: ["Python", "C++", "C"]
-frameworks: ["MQT"]
+title: MQT Debugger
+languages:
+  - Python
+  - C++
+  - C
+frameworks:
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/debugger"
-  github: "https://github.com/munich-quantum-toolkit/debugger"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/debugger
+  github: https://github.com/munich-quantum-toolkit/debugger
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 A semi-automated quantum program debugging tool.

--- a/_components/mqt-naviz.md
+++ b/_components/mqt-naviz.md
@@ -1,11 +1,15 @@
 ---
-title: "MQT NAViz"
-languages: ["Rust", " Python"]
-frameworks: ["MQT"]
+title: MQT NAViz
+languages:
+  - Rust
+  - " Python"
+frameworks:
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/naviz"
-  github: "https://github.com/munich-quantum-toolkit/naviz"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/naviz
+  github: https://github.com/munich-quantum-toolkit/naviz
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 An open-source Rust and Python library to visualize atom movements of neutral atom quantum

--- a/_components/mqt-predictor.md
+++ b/_components/mqt-predictor.md
@@ -1,11 +1,17 @@
 ---
-title: "MQT Predictor"
-languages: ["Python"]
-frameworks: ["Qiskit", "TKET", "BQSKit", "MQT"]
+title: MQT Predictor
+languages:
+  - Python
+frameworks:
+  - Qiskit
+  - TKET
+  - BQSKit
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/predictor"
-  github: "https://github.com/munich-quantum-toolkit/predictor"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/predictor
+  github: https://github.com/munich-quantum-toolkit/predictor
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 A tool for automatic device selection with device-specific circuit compilation for quantum computing

--- a/_components/mqt-problemsolver.md
+++ b/_components/mqt-problemsolver.md
@@ -1,11 +1,15 @@
 ---
-title: "MQT ProblemSolver"
-languages: ["Python"]
-frameworks: ["Qiskit", "MQT"]
+title: MQT ProblemSolver
+languages:
+  - Python
+frameworks:
+  - Qiskit
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/problemsolver"
-  github: "https://github.com/munich-quantum-toolkit/problemsolver"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/problemsolver
+  github: https://github.com/munich-quantum-toolkit/problemsolver
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 A framework for users with little to no quantum computing knowledge to solve common problems.

--- a/_components/mqt-qcec.md
+++ b/_components/mqt-qcec.md
@@ -1,11 +1,16 @@
 ---
-title: "MQT QCEC"
-languages: ["Python", "C++"]
-frameworks: ["Qiskit", "MQT"]
+title: MQT QCEC
+languages:
+  - Python
+  - C++
+frameworks:
+  - Qiskit
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/qcec"
-  github: "https://github.com/munich-quantum-toolkit/qcec"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/qcec
+  github: https://github.com/munich-quantum-toolkit/qcec
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 A tool for quantum circuit equivalence checking.

--- a/_components/mqt-qecc.md
+++ b/_components/mqt-qecc.md
@@ -1,11 +1,16 @@
 ---
-title: "MQT QECC"
-languages: ["Python"]
-frameworks: ["Qiskit", "Stim", "MQT"]
+title: MQT QECC
+languages:
+  - Python
+frameworks:
+  - Qiskit
+  - Stim
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/qecc"
-  github: "https://github.com/munich-quantum-toolkit/qecc"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/qecc
+  github: https://github.com/munich-quantum-toolkit/qecc
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 A collection of tools for decoding and synthesizing fault-tolerant quantum circuits.

--- a/_components/mqt-qmap.md
+++ b/_components/mqt-qmap.md
@@ -1,11 +1,16 @@
 ---
-title: "MQT QMAP"
-languages: ["Python", "C++"]
-frameworks: ["Qiskit", "MQT"]
+title: MQT QMAP
+languages:
+  - Python
+  - C++
+frameworks:
+  - Qiskit
+  - MQT
 links:
-  docs: "https://mqt.readthedocs.io/projects/qmap"
-  github: "https://github.com/munich-quantum-toolkit/qmap"
-maintainers: ["TUM (CDA) / MQSC"]
+  docs: https://mqt.readthedocs.io/projects/qmap
+  github: https://github.com/munich-quantum-toolkit/qmap
+maintainers:
+  - TUM (CDA) / MQSC
 ---
 
 A tool for quantum circuit compilation for various qubit technologies.

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ title: Component Overview
 <section class="components-section">
   <h3 class="section-title">Components</h3>
   <div class="component-grid">
-    {% for component in site.components %}
+    {% assign comps = site.components | sort: 'stars' | reverse %} {% for component in comps %}
     <div class="component-box">
       <div class="component-header">
         <h2>{{ component.title }}</h2>

--- a/scripts/clean_frontmatter_stars.py
+++ b/scripts/clean_frontmatter_stars.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Remove the `stars` key from YAML frontmatter of all `_components/*.md` files.
+
+Intended to be used as a pre-commit hook (e.g. via pre-commit). The script
+edits files in-place only when necessary and prints a short summary.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENTS_DIR = ROOT / "_components"
+
+
+def strip_stars_from_text(text: str) -> tuple[str, bool]:
+    """Remove the stars entry from a frontmatter.
+
+    Args:
+        text (str): The frontmatter text to reformat.
+
+    Returns:
+        tuple[str, bool]: The parsed YAML entries.
+    """
+    m = re.match(r"^---\n(.*?)\n---\n(.*)$", text, re.DOTALL)
+    if not m:
+        return text, False
+    fm_raw, body = m.group(1), m.group(2)
+    try:
+        fm = yaml.safe_load(fm_raw) or {}
+    except yaml.YAMLError:
+        # If YAML parsing fails, don't touch the file
+        return text, False
+
+    if "stars" not in fm:
+        return text, False
+
+    fm.pop("stars", None)
+    new_fm = yaml.safe_dump(fm, sort_keys=False).strip()
+    new_text = f"---\n{new_fm}\n---\n{body}"
+    return new_text, True
+
+
+def main() -> int:
+    """Main entry point.
+
+    Returns:
+        int: 1 if an error occurred, otherwise 0.
+    """
+    github_stars_file = ROOT / "assets" / "js" / "github-stars.json"
+    if github_stars_file.exists():
+        github_stars_file.unlink()
+
+    md_files = sorted(COMPONENTS_DIR.glob("*.md"))
+    changed = []
+    for p in md_files:
+        text = p.read_text(encoding="utf-8")
+        new_text, modified = strip_stars_from_text(text)
+        if modified:
+            p.write_text(new_text, encoding="utf-8")
+            changed.append(str(p))
+
+    if changed:
+        print("Removed 'stars' from frontmatter in:")
+        for c in changed:
+            print(" - ", c)
+        # Exit non-zero to make pre-commit fail and let user re-run commit/inspect
+        return 1
+
+    print("No 'stars' keys found in component frontmatter.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/clean_frontmatter_stars.py
+++ b/scripts/clean_frontmatter_stars.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import yaml
-
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENTS_DIR = ROOT / "_components"
 
@@ -29,18 +27,20 @@ def strip_stars_from_text(text: str) -> tuple[str, bool]:
     if not m:
         return text, False
     fm_raw, body = m.group(1), m.group(2)
-    try:
-        fm = yaml.safe_load(fm_raw) or {}
-    except yaml.YAMLError:
-        # If YAML parsing fails, don't touch the file
+
+    # Edit raw frontmatter lines to remove any 'stars:' entry while preserving
+    # all other formatting (leading spaces, quoting, list styles).
+    lines = fm_raw.splitlines(keepends=True)
+    pattern = re.compile(r"^\s*stars\s*:\s*.*$")
+    new_lines = [ln for ln in lines if not pattern.match(ln.rstrip("\r\n"))]
+
+    if len(new_lines) == len(lines):
+        # nothing removed
         return text, False
 
-    if "stars" not in fm:
-        return text, False
-
-    fm.pop("stars", None)
-    new_fm = yaml.safe_dump(fm, sort_keys=False).strip()
-    new_text = f"---\n{new_fm}\n---\n{body}"
+    # Reconstruct frontmatter preserving original line endings/layout
+    new_fm_raw = "".join(new_lines).rstrip("\n\r")
+    new_text = f"---\n{new_fm_raw}\n---\n{body}"
     return new_text, True
 
 

--- a/scripts/clean_frontmatter_stars.py
+++ b/scripts/clean_frontmatter_stars.py
@@ -48,12 +48,8 @@ def main() -> int:
     """Main entry point.
 
     Returns:
-        int: 1 if an error occurred, otherwise 0.
+        int: 1 if files were modified, otherwise 0.
     """
-    github_stars_file = ROOT / "assets" / "js" / "github-stars.json"
-    if github_stars_file.exists():
-        github_stars_file.unlink()
-
     md_files = sorted(COMPONENTS_DIR.glob("*.md"))
     changed = []
     for p in md_files:

--- a/scripts/fetch_stars.py
+++ b/scripts/fetch_stars.py
@@ -1,19 +1,12 @@
-#!/usr/bin/env -S uv run --script --quiet
-# /// script
-# requires-python = ">=3.10"
-# dependencies = [
-#     "pyyaml",
-#     "requests",
-# ]
-# ///
-"""Script for fetching GitHub star counts for components.
+#!/usr/bin/env python3
+"""Fetch GitHub stars for component repos.
 
-Read all Markdown files in _components/, extract `links.github` from YAML frontmatter,
-query the GitHub REST API for stargazer counts using GITHUB_TOKEN (if available),
-and write a JSON mapping to `assets/js/github-stars.json`.
+The result is attached to component
+frontmatter so Jekyll can sort by `stars` at build time. Also emits
+`assets/js/github-stars.json` for client-side fallback.
 
-This script is intended to be run from CI (GitHub Actions). It prints a short
-summary and writes the JSON file. It does not commit — the workflow will do that.
+Run this in CI before `jekyll build` so the modified `_components/*.md`
+files are read with `stars` present.
 """
 
 from __future__ import annotations
@@ -35,20 +28,35 @@ GITHUB_API = "https://api.github.com/repos/{owner}/{repo}"
 TOKEN = os.environ.get("GITHUB_TOKEN")
 
 
-def parse_frontmatter(md_text: str) -> dict:
-    """Returns YAML frontmatter between leading '---' blocks."""
-    m = re.match(r"^---\n(.*?)\n---\n", md_text, re.DOTALL)
+def parse_frontmatter_and_body(md_text: str) -> tuple[dict, str]:
+    """Parse the frontmatter of a markdown file and return its values.
+
+    Args:
+        md_text (str): The markdown text to parse.
+
+    Returns:
+        tuple[dict, str]: The frontmatter values.
+    """
+    m = re.match(r"^---\n(.*?)\n---\n(.*)$", md_text, re.DOTALL)
     if not m:
-        return {}
+        return {}, md_text
     try:
-        return yaml.safe_load(m.group(1)) or {}
-    except yaml.YAMLError as e:
-        print(f"Failed to parse frontmatter: {e}")
-        return {}
+        fm = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError:
+        fm = {}
+    body = m.group(2)
+    return fm, body
 
 
-def repo_from_url(url: str) -> str | None:
-    """Return extracted owner/repo from a GitHub URL."""
+def repo_from_url(url: str | None) -> str | None:
+    """Get the github repository ID from a github URL.
+
+    Args:
+        url (str | None): The URL to check.
+
+    Returns:
+        str | None: A repo identifier.
+    """
     if not url:
         return None
     m = re.search(r"github\.com/([^/]+)/([^/]+)", url)
@@ -60,13 +68,24 @@ def repo_from_url(url: str) -> str | None:
 
 
 def fetch_stars(owner_repo: str) -> int | None:
-    """Return GitHub stargazer count for a repo, or None on error."""
+    """Load the stars of a github repository.
+
+    Args:
+        owner_repo (str): The owner/repo identifier.
+
+    Returns:
+        int | None: The star count, or None on failure.
+    """
     owner, repo = owner_repo.split("/")
     url = GITHUB_API.format(owner=owner, repo=repo)
     headers = {"Accept": "application/vnd.github.v3+json"}
     if TOKEN:
         headers["Authorization"] = f"token {TOKEN}"
-    r = requests.get(url, headers=headers, timeout=20)
+    try:
+        r = requests.get(url, headers=headers, timeout=20)
+    except requests.exceptions.RequestException as e:
+        print(f"Warning: request failed for {owner_repo}: {e}")
+        return None
     if r.status_code == 200:
         data = r.json()
         return data.get("stargazers_count")
@@ -75,16 +94,17 @@ def fetch_stars(owner_repo: str) -> int | None:
 
 
 def main() -> None:
-    """Main entry point."""
-    mapping = {}
+    """Load the stars of all components and store them into the frontmatter."""
+    mapping: dict[str, int | None] = {}
     files = sorted(COMPONENTS_DIR.glob("*.md"))
     if not files:
         print("No component files found in _components/")
         sys.exit(0)
 
+    # First pass: collect repos and fetch counts
     for f in files:
         text = f.read_text(encoding="utf-8")
-        fm = parse_frontmatter(text)
+        fm, _ = parse_frontmatter_and_body(text)
         links = fm.get("links") or {}
         gh = links.get("github")
         repo = repo_from_url(gh)
@@ -93,14 +113,26 @@ def main() -> None:
             mapping[repo] = stars
             key = repo
         else:
-            # If there's no links.github, skip but keep filename trackable
             key = f.name
             mapping[key] = None
         print(f"Processed {f.name}: {key} -> {mapping.get(key)}")
 
+    # Second pass: write 'stars' into frontmatter of each component file so
+    # Jekyll can sort by it during the build.
+    for f in files:
+        text = f.read_text(encoding="utf-8")
+        fm, body = parse_frontmatter_and_body(text)
+        links = fm.get("links") or {}
+        repo = repo_from_url(links.get("github"))
+        stars = mapping.get(repo) if repo in mapping else None
+        fm["stars"] = stars
+        new_fm = yaml.safe_dump(fm, sort_keys=False).strip()
+        new_text = f"---\n{new_fm}\n---\n{body}"
+        f.write_text(new_text, encoding="utf-8")
+
     OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
     OUT_FILE.write_text(json.dumps(mapping, indent=2), encoding="utf-8")
-    print(f"Wrote {OUT_FILE} with {len(mapping)} entries")
+    print(f"Wrote {OUT_FILE} with {len(mapping)} entries and updated component files")
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_stars.py
+++ b/scripts/fetch_stars.py
@@ -28,7 +28,7 @@ GITHUB_API = "https://api.github.com/repos/{owner}/{repo}"
 TOKEN = os.environ.get("GITHUB_TOKEN")
 
 
-def parse_frontmatter_and_body(md_text: str) -> tuple[dict, str]:
+def parse_frontmatter_and_body(md_text: str) -> tuple[dict, str, str]:
     """Parse the frontmatter of a markdown file and return its values.
 
     Args:
@@ -45,7 +45,8 @@ def parse_frontmatter_and_body(md_text: str) -> tuple[dict, str]:
     except yaml.YAMLError:
         fm = {}
     body = m.group(2)
-    return fm, body
+    raw = m.group(1)
+    return fm, body, raw
 
 
 def repo_from_url(url: str | None) -> str | None:
@@ -104,7 +105,7 @@ def main() -> None:
     # First pass: collect repos and fetch counts
     for f in files:
         text = f.read_text(encoding="utf-8")
-        fm, _ = parse_frontmatter_and_body(text)
+        fm, _, _ = parse_frontmatter_and_body(text)
         links = fm.get("links") or {}
         gh = links.get("github")
         repo = repo_from_url(gh)
@@ -121,13 +122,22 @@ def main() -> None:
     # Jekyll can sort by it during the build.
     for f in files:
         text = f.read_text(encoding="utf-8")
-        fm, body = parse_frontmatter_and_body(text)
+        fm, body, raw = parse_frontmatter_and_body(text)
         links = fm.get("links") or {}
         repo = repo_from_url(links.get("github"))
         stars = mapping.get(repo) if repo in mapping else None
-        fm["stars"] = stars
-        new_fm = yaml.safe_dump(fm, sort_keys=False).strip()
-        new_text = f"---\n{new_fm}\n---\n{body}"
+        # Update raw frontmatter text to avoid changing formatting/styles for
+        # lists and quoting. We remove any existing 'stars:' line and insert a
+        # new one at the top of the frontmatter.
+        lines = raw.splitlines(keepends=True)
+        # Remove existing stars lines
+        lines = [ln for ln in lines if not re.match(r"^\s*stars\s*:\s*", ln)]
+        # Prepare value
+        val = "null" if stars is None else str(stars)
+        # Insert at top
+        lines.insert(0, f"stars: {val}\n")
+        new_raw = "".join(lines).rstrip("\n")
+        new_text = f"---\n{new_raw}\n---\n{body}"
         f.write_text(new_text, encoding="utf-8")
 
     OUT_FILE.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This PR changes the ordering of entries in the component catalog so that the entries with the most stars appear first.

The simplest way to do this requires the stars to be already included in the components' frontmatters. Therefore, the `fetch_stars.py` script now loads the values into the frontmatters.

This feature also requires some additional features:
- Until now, the frontmatters of the components did not use the "canonical" markdown syntax. This had to be updated for all existing components and for the automatic component generation workflow, in particular for:
  - strings (here, quotation marks are not required)
  - arrays (using enumeration points starting with `-` is more standard than using square brackets)
- A pre-commit hook has been added that removes fetched star counts if the page has been built locally so that the stars never make it into the repository. 