### PR TITLE
Fix to MQSS MQP Dashboard Frontend

### DIFF
--- a/_components/mqss_mqp_dashboard_frontend.md
+++ b/_components/mqss_mqp_dashboard_frontend.md
@@ -5,6 +5,7 @@ languages:
 frameworks:
   - React
 links:
+  docs: https://github.com/Munich-Quantum-Software-Stack/MQP-Dashboard-Frontend/blob/main/README.md
   github: https://github.com/Munich-Quantum-Software-Stack/MQP-Dashboard-Frontend
 maintainers:
   - LRZ (QCT)

--- a/_components/mqss_mqp_dashboard_frontend.md
+++ b/_components/mqss_mqp_dashboard_frontend.md
@@ -5,10 +5,9 @@ languages:
 frameworks:
   - React
 links:
-  docs:
   github: https://github.com/Munich-Quantum-Software-Stack/MQP-Dashboard-Frontend
 maintainers:
   - LRZ (QCT)
 ---
 
-Web bashboard to view available back-ends, generate personal toket, display run jobs with details. Provide also access to telemetry data.
+Web dashboard to view available backends, generate a personal access token, and display detailed job results. Also provides access to telemetry data.

--- a/_components/mqss_mqp_dashboard_frontend.md
+++ b/_components/mqss_mqp_dashboard_frontend.md
@@ -11,4 +11,5 @@ maintainers:
   - LRZ (QCT)
 ---
 
-Web dashboard to view available backends, generate a personal access token, and display detailed job results. Also provides access to telemetry data.
+Web dashboard to view available backends, generate a personal access token, and display detailed job
+results. Also provides access to telemetry data.


### PR DESCRIPTION
This PR introduces:

- typos fixes in the component description
- `docs` field linking to MQP Dashboard Fronted README as temporary documentation
- component file renamed, adding `.md` extension